### PR TITLE
update post destination slug

### DIFF
--- a/build-e-guichet/datasources/datasources.json
+++ b/build-e-guichet/datasources/datasources.json
@@ -135,7 +135,7 @@
           "text": "Envoi \u00e0 domicile",
           "price": "1.0",
           "paymentrequired": true,
-          "slug": "poste",
+          "slug": "envoi-a-domicile",
           "description": "Mode de r\u00e9ception : envoi \u00e0 domicile"
         },
         {


### PR DESCRIPTION
The problem is by default the slug is 'poste' and when the user updates the price and validate the form, wcs slugify the 'label' and it becomes 'envoi-a-domicile' which cause errors and support so I suggest we use 'envoie-a-domicile' as the default slug.